### PR TITLE
Added a FlatEnvLayer

### DIFF
--- a/env_layer.go
+++ b/env_layer.go
@@ -50,3 +50,19 @@ func NewEnvLayerPrefix(separator string, prefix string) Layer {
 
 	return NewMapLayer(data)
 }
+
+// NewFlatEnvLayerPrefix create new env layer, with all values with the same prefix however
+// this does not seperate the value hierarchically. This can be used for layered configurations
+// such as csv or ini instead of json or yaml.
+func NewFlatEnvLayerPrefix(separator string, prefix string) Layer {
+	var data map[string]interface{}
+	pf := strings.ToUpper(prefix) + separator
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, pf) {
+			k := strings.Trim(strings.Split(env, "=")[0], "\t\n ")
+			ck := strings.ToLower(strings.TrimPrefix(k, pf))
+			data = buildMap(data, os.Getenv(k), ck)
+		}
+	}
+	return NewMapLayer(data)
+}

--- a/env_layer_test.go
+++ b/env_layer_test.go
@@ -18,5 +18,9 @@ func TestNewEnvLayer(t *testing.T) {
 		l2 := NewEnvLayerPrefix("_", "key")
 		o2 := New(l2)
 		So(o2.GetInt("test.sep"), ShouldEqual, 1)
+
+		l3 := NewFlatEnvLayerPrefix("_", "key")
+		o3 := New(l3)
+		So(o3.GetInt("test_sep"), ShouldEqual, 1)
 	})
 }


### PR DESCRIPTION
I copied and and configured NewFlatEnvLayerPrefix from NewEnvLayerPrefix to solve the issue of needing an environment variable that corresponds to a configuration that is not hierarchical. For example, if one wanted to use onion to parse fields from a layer that they had implemented, and that filetype was not hierarchical, then the env layer with prefix would not match the configuration file. With this function, the Prefix + Separator will be stripped off of the beginning, but the rest of the name will remain the same.